### PR TITLE
Update tiled-demo URL.

### DIFF
--- a/src/stories/Tiled.stories.ts
+++ b/src/stories/Tiled.stories.ts
@@ -281,7 +281,7 @@ export const Primary: Story = {
     reverseSort: false,
     enableStartupScreen: false,
     size: 'medium',
-    tiledBaseUrl: 'https://tiled-demo.blueskyproject.io/api/v1',
+    tiledBaseUrl: 'https://tiled-demo.nsls2.bnl.gov/api/v1',
     onSelectCallback: (links) => console.log('Selected Tiled link:', links.self),
     isButtonMode: false,
     isPopup: false,
@@ -311,7 +311,7 @@ export const CustomUrl: Story = {
     args: {
       isButtonMode: true,
       size: 'medium',
-      tiledBaseUrl: 'https://tiled-demo.blueskyproject.io/api/v1',
+      tiledBaseUrl: 'https://tiled-demo.nsls2.bnl.gov/api/v1',
       reverseSort: false,
     },
   };


### PR DESCRIPTION
The tiled-demo was moved from `tiled-demo.blueskyproject.io` to
`tiled-demo.nsls2.bnl.gov`.  This was done for purely practical reasons: we can use
existing NSLS2 automation to keep the system patched and manage the certs,
reducing maintenance labor.  The site remains and will remain world-public. The
CORS configuration from the old demo was initially missing but has now been
copied over.

We intend to manage the tiled configuration (not the _system_ configuration)
in public, but we have done implemented that just yet.
