### PR TITLE
Fix/tiled plot maker

### DIFF
--- a/src/components/Tiled/TiledWriterMultiScatterPlot.tsx
+++ b/src/components/Tiled/TiledWriterMultiScatterPlot.tsx
@@ -9,6 +9,8 @@ type TiledWriterMultiScatterPlotProps = {
     blueskyRunIds: string[];
     /** Base URL of the Tiled server forwarded to `TiledMultiScatterPlot`. */
     tiledBaseUrl?: string;
+    /** Initial path for the Tiled search. */
+    initialPath?: string;
     /** Additional class names applied to the `TiledMultiScatterPlot` container. */
     className?: string;
     /** Additional class names applied to the plot inside `TiledMultiScatterPlot`. */
@@ -27,9 +29,11 @@ export default function TiledWriterMultiScatterPlot({
     plotClassName,
     title,
     traceNames,
+    initialPath,
 }: TiledWriterMultiScatterPlotProps) {
     const { tiledPaths, isLoading, errors } = useTiledWriterMultiScatterPlot(blueskyRunIds, {
         tiledBaseUrl,
+        initialPath,
     });
     const errorMessage = isLoading
         ? undefined

--- a/src/components/Tiled/TiledWriterScatterPlot.tsx
+++ b/src/components/Tiled/TiledWriterScatterPlot.tsx
@@ -13,6 +13,8 @@ type TiledWriterScatterPlotProps = {
     partition?: number;
     /** Base URL of the Tiled server forwarded to `TiledScatterPlot`. */
     tiledBaseUrl?: string;
+    /** Initial path for the Tiled search, e.g. `beamline531`. */
+    initialPath?: string;
     /** Milliseconds between data refetches while the run is ongoing. Defaults to `1000`. */
     pollingIntervalMs?: number;
     /** Additional class names applied to the `TiledScatterPlot` container. */
@@ -29,6 +31,7 @@ export default function TiledWriterScatterPlot({
     isRunFinished = false,
     partition,
     tiledBaseUrl,
+    initialPath,
     pollingIntervalMs,
     className,
     plotClassName,
@@ -39,6 +42,7 @@ export default function TiledWriterScatterPlot({
         isRunFinished,
         pollingIntervalMs,
         tiledBaseUrl,
+        initialPath,
     });
 
     // Determine status text based on current state

--- a/src/components/Tiled/hooks/useTiledWriterMultiScatterPlot.ts
+++ b/src/components/Tiled/hooks/useTiledWriterMultiScatterPlot.ts
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import { useQueries } from '@tanstack/react-query';
 import { getSearchResults, TiledSearchConfig } from '@blueskyproject/tiled';
 import { useTiledApiUrls } from 'src/utils/apiUtils';
+import { cleanTiledInitialPath } from 'src/components/Tiled/utils/tiledUtils';
 
 async function searchById(config: TiledSearchConfig): Promise<unknown | null> {
     try {
@@ -23,6 +24,8 @@ type UseTiledWriterMultiScatterPlotReturn = {
 type UseTiledWriterMultiScatterPlotOptions = {
     /** The base URL for the Tiled server, e.g. `http://localhost:8000/api/v1`. */
     tiledBaseUrl?: string;
+    /** The initial path to use for the Tiled search, e.g. `beamline531`. */
+    initialPath?: string;
 };
 
 export const useTiledWriterMultiScatterPlot = (
@@ -32,11 +35,20 @@ export const useTiledWriterMultiScatterPlot = (
     const { httpBaseUrl, apiKey: rawApiKey } = useTiledApiUrls();
     const baseUrl = options.tiledBaseUrl ?? httpBaseUrl;
     const apiKey = rawApiKey ?? undefined;
+    const startPath =
+        options.initialPath && options.initialPath.trim()
+            ? `${cleanTiledInitialPath(options.initialPath)}/`
+            : '';
 
     const primaryQueries = useQueries({
         queries: blueskyRunIds.map((id) => ({
-            queryKey: ['tiled', 'searchById', baseUrl, { path: `${id}/primary` }],
-            queryFn: () => searchById({ baseUrl, apiKey, path: `${id}/primary` }),
+            queryKey: ['tiled', 'searchById', baseUrl, { path: `${startPath}${id}/primary` }],
+            queryFn: () =>
+                searchById({
+                    baseUrl,
+                    apiKey,
+                    path: `${startPath}${id}/primary`,
+                }),
             enabled: !!id?.trim(),
             retry: false,
         })),
@@ -46,7 +58,7 @@ export const useTiledWriterMultiScatterPlot = (
         () =>
             blueskyRunIds.map((id, i) => {
                 const primaryFound = primaryQueries[i]?.isSuccess && !!primaryQueries[i]?.data;
-                return primaryFound ? `${id}/primary/internal` : null;
+                return primaryFound ? `${startPath}${id}/primary/internal` : null;
             }),
         [blueskyRunIds, primaryQueries],
     );

--- a/src/components/Tiled/hooks/useTiledWriterScatterPlot.ts
+++ b/src/components/Tiled/hooks/useTiledWriterScatterPlot.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import { useTiledSearchByIdQuery } from '@/api/tiled/hooks';
-import { checkRunCompletion } from '../utils/tiledUtils';
+import { checkRunCompletion, cleanTiledInitialPath } from '../utils/tiledUtils';
 
 type UseTiledWriterScatterPlotReturn = {
     /** Resolved Tiled path to the primary stream data, or `null` while searching. */
@@ -24,13 +24,18 @@ type UseTiledWriterScatterPlotOptions = {
     pollingIntervalMs?: number;
     /** The base url for the tiled server, ex) http://localhost:8000/api/v1 */
     tiledBaseUrl?: string;
+    /** The initial path to use for the tiled search, ex) beamline531 */
+    initialPath?: string;
 };
 
 export const useTiledWriterScatterPlot = (
     blueskyRunId: string,
     options: UseTiledWriterScatterPlotOptions = {},
 ): UseTiledWriterScatterPlotReturn => {
-    const { isRunFinished = false, pollingIntervalMs = 5000, tiledBaseUrl } = options;
+    const { isRunFinished = false, pollingIntervalMs = 5000, tiledBaseUrl, initialPath } = options;
+
+    const startPath =
+        initialPath && initialPath.trim() ? `${cleanTiledInitialPath(initialPath)}/` : '';
 
     const [enablePolling, setEnablePolling] = useState(!isRunFinished);
     const [pollingInterval, setPollingInterval] = useState<ReturnType<typeof setInterval> | null>(
@@ -42,7 +47,7 @@ export const useTiledWriterScatterPlot = (
 
     // Step 1: Verify the run exists in Tiled. Retries every 2 s until found (unless finished).
     const runQuery = useTiledSearchByIdQuery(
-        { path: blueskyRunId },
+        { path: `${startPath}${blueskyRunId}` },
         {
             enabled: hasRunId,
             retry: false,
@@ -53,7 +58,7 @@ export const useTiledWriterScatterPlot = (
 
     // Step 2: Fetch the primary path directly under the run ID.
     const directQuery = useTiledSearchByIdQuery(
-        { path: `${blueskyRunId}/primary` },
+        { path: `${startPath}${blueskyRunId}/primary` },
         {
             enabled: runExists,
             retry: false,
@@ -63,9 +68,9 @@ export const useTiledWriterScatterPlot = (
     const directFound = directQuery.isSuccess && !!directQuery.data;
 
     const tiledPath = useMemo(() => {
-        if (directFound) return `${blueskyRunId}/primary/internal`;
+        if (directFound) return `${startPath}${blueskyRunId}/primary/internal`;
         return null;
-    }, [directFound, blueskyRunId]);
+    }, [directFound, startPath, blueskyRunId]);
 
     const isLoading = useMemo(() => {
         if (!hasRunId || tiledPath) return false;

--- a/src/components/Tiled/utils/tiledUtils.tsx
+++ b/src/components/Tiled/utils/tiledUtils.tsx
@@ -59,3 +59,23 @@ export const checkRunCompletion = async (path: string, url?: string): Promise<bo
         return false;
     }
 };
+
+/**
+ * Returns a cleaned version of the initial path for Tiled searches.
+ * Removes leading and trailing slashes and whitespace.
+ * Returns `undefined` if the cleaned path is empty or if the input is `undefined`.
+ *
+ * @example
+ * cleanTiledInitialPath('  /beamline531/  ') // returns 'beamline531'
+ * cleanTiledInitialPath('/beamline531/') // returns 'beamline531'
+ * cleanTiledInitialPath('') // returns undefined
+ * cleanTiledInitialPath(undefined) // returns undefined
+ * @param path
+ * @returns
+ */
+export const cleanTiledInitialPath = (path: string | undefined): string | undefined => {
+    if (!path) return undefined;
+    // Remove leading and trailing slashes and whitespace
+    const cleanedPath = path.trim().replace(/^\/+|\/+$/g, '');
+    return cleanedPath || undefined; // Return undefined if the cleaned path is empty
+};

--- a/src/features/TiledLinePlotMaker.tsx
+++ b/src/features/TiledLinePlotMaker.tsx
@@ -51,10 +51,8 @@ export default function TiledLinePlotMaker({
     const [blueskyIds, setBlueskyIds] = useState<string[]>([]);
     const [traceNames, setTraceNames] = useState<Record<string, string>>({});
     const [plotTitle, setPlotTitle] = useState('');
-    const [xAxis, setXAxis] = useState(
-        import.meta.env.VITE_XAS_SCATTER_X ?? 'mono_energy_energy_eV',
-    );
-    const [yAxis, setYAxis] = useState(import.meta.env.VITE_XAS_SCATTER_Y ?? 'amptek_fluo_roi_sum');
+    const [xAxis, setXAxis] = useState('seq_num');
+    const [yAxis, setYAxis] = useState('time');
     const handleIDSelect = (id: string) => {
         setBlueskyIds((prev) => [...prev, id]);
     };

--- a/src/features/TiledLinePlotMaker.tsx
+++ b/src/features/TiledLinePlotMaker.tsx
@@ -351,6 +351,8 @@ export default function TiledLinePlotMaker({
                 title={plotTitle || undefined}
                 className={cn('h-full border-2 border-black/20', classNamePlot)}
                 plotClassName="h-full"
+                tiledBaseUrl={tiledBaseUrl}
+                initialPath={initialPath}
             />
         </article>
     );

--- a/src/testing/tests/TiledComponents.test.tsx
+++ b/src/testing/tests/TiledComponents.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, beforeAll } from 'vitest';
 
 // ── Mocks ─────────────────────────────────────────────────────────────────────
 
@@ -11,6 +11,7 @@ vi.mock('react-plotly.js', () => ({
 // both when tested directly and when rendered inside TiledWriterScatterPlot.
 vi.mock('@tanstack/react-query', () => ({
     useQuery: vi.fn(),
+    useQueries: vi.fn(),
 }));
 
 vi.mock('../../components/PlotlyScatter', () => ({
@@ -69,7 +70,17 @@ vi.mock('../../components/Tiled/TiledMultiScatterPlot', () => ({
 
 // ── Imports (after mocks) ──────────────────────────────────────────────────────
 
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueries } from '@tanstack/react-query';
+
+// Loaded via vi.importActual so the real component runs against the mocked hooks above.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let RealTiledMultiScatterPlot: any;
+beforeAll(async () => {
+    const mod = await vi.importActual<{ default: unknown }>(
+        '../../components/Tiled/TiledMultiScatterPlot',
+    );
+    RealTiledMultiScatterPlot = mod.default;
+});
 import { useTiledWriterDetImageHeatmap } from '../../components/Tiled/hooks/useTiledWriterDetImageHeatmap';
 import { useTiledWriterScatterPlot } from '../../components/Tiled/hooks/useTiledWriterScatterPlot';
 import { useTiledWriterMultiScatterPlot } from '../../components/Tiled/hooks/useTiledWriterMultiScatterPlot';
@@ -474,5 +485,71 @@ describe('TiledWriterMultiScatterPlot', () => {
             />,
         );
         expect(screen.getByTestId('multi-scatter-plot')).toHaveAttribute('data-title', 'My Scans');
+    });
+});
+
+// ── TiledMultiScatterPlot ─────────────────────────────────────────────────────
+
+describe('TiledMultiScatterPlot', () => {
+    function makeResult(
+        overrides: Partial<{ data: unknown; isLoading: boolean; error: unknown }> = {},
+    ) {
+        return { data: undefined, isLoading: false, error: null, ...overrides };
+    }
+
+    beforeEach(() => {
+        vi.mocked(useQueries).mockReturnValue([makeResult()]);
+    });
+
+    it('renders the PlotlyScatter component', () => {
+        render(<RealTiledMultiScatterPlot tiledTrace={trace} paths={[null]} />);
+        expect(screen.getByTestId('plotly-scatter')).toBeInTheDocument();
+    });
+
+    it('shows waiting overlay when all paths are null', () => {
+        vi.mocked(useQueries).mockReturnValue([makeResult(), makeResult()]);
+        render(<RealTiledMultiScatterPlot tiledTrace={trace} paths={[null, null]} />);
+        expect(screen.getByText('No data paths provided - waiting for paths')).toBeInTheDocument();
+    });
+
+    it('shows loading overlay when any query is loading', () => {
+        vi.mocked(useQueries).mockReturnValue([makeResult({ isLoading: true })]);
+        render(<RealTiledMultiScatterPlot tiledTrace={trace} paths={['/some/path']} />);
+        expect(screen.getByText('Loading data...')).toBeInTheDocument();
+    });
+
+    it('shows error overlay when a query fails', () => {
+        vi.mocked(useQueries).mockReturnValue([
+            makeResult({ error: new Error('network timeout') }),
+        ]);
+        render(<RealTiledMultiScatterPlot tiledTrace={trace} paths={['/some/path']} />);
+        expect(screen.getByText('Error loading data: network timeout')).toBeInTheDocument();
+    });
+
+    it('shows popupMessage overlay and suppresses other overlays', () => {
+        vi.mocked(useQueries).mockReturnValue([makeResult({ isLoading: true })]);
+        render(
+            <RealTiledMultiScatterPlot
+                tiledTrace={trace}
+                paths={['/some/path']}
+                popupMessage="Something went wrong"
+            />,
+        );
+        expect(screen.getByText('Something went wrong')).toBeInTheDocument();
+        expect(screen.queryByText('Loading data...')).not.toBeInTheDocument();
+    });
+
+    it('shows column-mismatch overlay when x or y column is absent from data', () => {
+        vi.mocked(useQueries).mockReturnValue([makeResult({ data: { other: [1, 2] } })]);
+        render(<RealTiledMultiScatterPlot tiledTrace={trace} paths={['/some/path']} />);
+        expect(screen.getByText(/Column not found/)).toBeInTheDocument();
+        expect(screen.getByText('other')).toBeInTheDocument();
+    });
+
+    it('applies custom className to the container', () => {
+        const { container } = render(
+            <RealTiledMultiScatterPlot tiledTrace={trace} paths={[null]} className="my-class" />,
+        );
+        expect(container.firstChild).toHaveClass('my-class');
     });
 });

--- a/src/testing/tests/TiledLinePlotMaker.test.tsx
+++ b/src/testing/tests/TiledLinePlotMaker.test.tsx
@@ -83,8 +83,8 @@ describe('TiledLinePlotMaker', () => {
         render(<TiledLinePlotMaker />);
         await waitFor(() => expect(getSearchResults).toHaveBeenCalled());
         const plot = screen.getByTestId('multi-scatter-plot');
-        expect(plot).toHaveAttribute('data-x', 'mono_energy_energy_eV');
-        expect(plot).toHaveAttribute('data-y', 'amptek_fluo_roi_sum');
+        expect(plot).toHaveAttribute('data-x', 'seq_num');
+        expect(plot).toHaveAttribute('data-y', 'time');
     });
 
     it('forwards the plot title from the title input', async () => {


### PR DESCRIPTION
- Modified the `TiledMultiScatterPlot` to accept an initial path arg
- Prop drilled the `tiledBaseUrl` from `TiledLinePlotMaker` into `TiledMultiScatterPlot` which addresses #46 
- Added utility to sanitize tiled initial path args
- Removed some env vars used during initial testing of the plot maker