### PR TITLE
feat(storybook): add Ophyd Sim docs page + Ophyd Components stories

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -22,6 +22,7 @@ const preview: Preview = {
             "Installation",
             "Configuration",
             "BackendSetup",
+            "Ophyd Sim",
             "API Hooks",
           ],
           "Bluesky Components",  [
@@ -33,6 +34,7 @@ const preview: Preview = {
               ]
             ]
           ],
+          "Ophyd Components",
           "Layout Components",
           "General Components",
         ],

--- a/src/components/Camera/CameraContainer.tsx
+++ b/src/components/Camera/CameraContainer.tsx
@@ -32,6 +32,8 @@ export type CameraContainerProps = {
     cameraImageWsUrl?: string;
     /** WebSocket URL for the camera control PV subscription. Falls back to the application default when omitted. */
     cameraControlWsUrl?: string;
+    /** Begin streaming frames automatically on mount instead of waiting for the Acquire button. Defaults to `false`. */
+    autoStart?: boolean;
 };
 export default function CameraContainer({
     prefix = '13SIM1',
@@ -43,6 +45,7 @@ export default function CameraContainer({
     sizePVs,
     cameraImageWsUrl,
     cameraControlWsUrl,
+    autoStart = false,
 }: CameraContainerProps) {
     const { devices, startAcquire, stopAcquire, onSubmitSettings, cameraControlPV } =
         useCameraContainer({ prefix, settings, enableControlPanel, cameraControlWsUrl });
@@ -56,6 +59,7 @@ export default function CameraContainer({
                     sizePVs={sizePVs}
                     prefix={prefix}
                     wsUrl={cameraImageWsUrl}
+                    autoStart={autoStart}
                 />
                 {enableControlPanel ? (
                     <CameraControlPanel

--- a/src/stories/OphydComponents/BeamEnergyOphyd.stories.tsx
+++ b/src/stories/OphydComponents/BeamEnergyOphyd.stories.tsx
@@ -1,0 +1,37 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import BeamEnergyOphyd from '@/components/BeamEnergy/BeamEnergyOphyd';
+import { withDeviceTransport } from '../demos/ophydSimDecorators';
+import { createMockDeviceTransport } from '../demos/mockDeviceTransport';
+
+/**
+ * Beam-energy widget wired by **Ophyd device name** (not raw PV). It subscribes
+ * over the device socket (`useOphydDeviceSocket`) and reads the energy in eV
+ * directly from the device value.
+ *
+ * ophyd-sim only implements a *PV* transport, so this variant can't be driven by
+ * it. Instead a small mock device transport (see `mockDeviceTransport.ts`) stands
+ * in for a device-socket backend and serves a writable `mono_energy` device — so
+ * the absolute/relative energy moves below are live. The transport is supplied by
+ * a decorator; the sample code shows only the component.
+ */
+const deviceTransport = createMockDeviceTransport({
+    mono_energy: { initialValue: 4500, units: 'eV', min: 2000, max: 7000, writable: true },
+});
+
+const meta = {
+    title: 'Ophyd Components/BeamEnergyOphyd',
+    component: BeamEnergyOphyd,
+    tags: ['autodocs'],
+    parameters: { layout: 'centered' },
+    decorators: [withDeviceTransport(deviceTransport)],
+} satisfies Meta<typeof BeamEnergyOphyd>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    render: () => <BeamEnergyOphyd deviceName="mono_energy" />,
+    parameters: {
+        docs: { source: { code: '<BeamEnergyOphyd deviceName="mono_energy" />', language: 'tsx' } },
+    },
+};

--- a/src/stories/OphydComponents/BeamEnergyPV.stories.tsx
+++ b/src/stories/OphydComponents/BeamEnergyPV.stories.tsx
@@ -1,0 +1,30 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import BeamEnergyPV from '@/components/BeamEnergy/BeamEnergyPV';
+
+/**
+ * Beam-energy widget wired by **EPICS PV** — it reads a monochromator angle PV
+ * (default `bl531_xps1:mono_angle_deg`) via `useOphydPVSocket` and converts the
+ * Bragg angle to energy.
+ *
+ * This story uses the component's built-in `demo` mode, which drives the display
+ * from a self-contained simulated monochromator (no backend, no wrapper). To run
+ * it against a real IOC instead, drop `demo` and point `pv` at your angle PV; to
+ * drive it from ophyd-sim, wrap it in the sim providers with a scenario that
+ * seeds that PV.
+ */
+const meta = {
+    title: 'Ophyd Components/BeamEnergyPV',
+    component: BeamEnergyPV,
+    tags: ['autodocs'],
+    parameters: { layout: 'centered' },
+} satisfies Meta<typeof BeamEnergyPV>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    render: () => <BeamEnergyPV demo />,
+    parameters: {
+        docs: { source: { code: '<BeamEnergyPV demo />', language: 'tsx' } },
+    },
+};

--- a/src/stories/OphydComponents/Beamstop.stories.tsx
+++ b/src/stories/OphydComponents/Beamstop.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import Beamstop from '@/features/Beamstop';
+import { withOphydSim, beamstopBeamline } from '@/lib/ophyd-sim';
+
+/**
+ * Full beamstop-alignment feature: a live diode-current trend, X/Y motor
+ * controllers, an optional beam-energy control, and an Energy-vs-Current plot.
+ * It takes the PV names of its devices as props and wires them with
+ * `useOphydPVSocket`.
+ *
+ * The `beamstopBeamline` sim provides all of those PVs — the diode current is a
+ * derived signal that peaks when the stop is centered on the (energy-dependent)
+ * beam, so sweeping X/Y or energy changes the reading live. `enableBestOption`
+ * turns on the "Go To Best" helper that tracks the strongest current seen.
+ */
+const meta = {
+    title: 'Ophyd Components/Beamstop',
+    component: Beamstop,
+    tags: ['autodocs'],
+    parameters: { layout: 'fullscreen' },
+    decorators: [withOphydSim(beamstopBeamline)],
+} satisfies Meta<typeof Beamstop>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    render: () => (
+        <div className="h-[860px] w-full p-4">
+            <Beamstop
+                beamstopXName="bl531_xps2:beamstop_x_mm"
+                beamstopYName="bl531_xps2:beamstop_y_mm"
+                beamstopCurrentName="bl201-beamstop:current"
+                beamstopEnergyName="bl531:mono_energy_eV"
+                beamstopXTitle="Beamstop X"
+                beamstopYTitle="Beamstop Y"
+                enableBestOption
+                stackVertical={false}
+            />
+        </div>
+    ),
+    parameters: {
+        docs: {
+            source: {
+                code: `<Beamstop
+    beamstopXName="bl531_xps2:beamstop_x_mm"
+    beamstopYName="bl531_xps2:beamstop_y_mm"
+    beamstopCurrentName="bl201-beamstop:current"
+    beamstopEnergyName="bl531:mono_energy_eV"
+    beamstopXTitle="Beamstop X"
+    beamstopYTitle="Beamstop Y"
+    enableBestOption
+    stackVertical={false}
+/>`,
+                language: 'tsx',
+            },
+        },
+    },
+};

--- a/src/stories/OphydComponents/CameraContainer.stories.tsx
+++ b/src/stories/OphydComponents/CameraContainer.stories.tsx
@@ -11,9 +11,10 @@ import { withCameraSim } from '../demos/ophydSimDecorators';
  * Driven by the `beamstopBeamline` sim's `13SIM1` detector: the `withCameraSim`
  * decorator supplies both the PV transport and a simulated camera-socket factory,
  * so the canvas renders live derived frames with no backend. `autoStart` begins
- * the stream on mount (otherwise press **Acquire**); the settings panel is
- * disabled to keep the demo focused on the image. The sample code shows only the
- * component.
+ * the stream on mount (otherwise press **Acquire**). The settings panel and the
+ * PV-acquire control panel are disabled here, leaving the canvas's own
+ * Acquire/Pause stream controls, to keep the demo focused on the image. The
+ * sample code shows only the component.
  */
 const meta = {
     title: 'Ophyd Components/CameraContainer',
@@ -32,6 +33,7 @@ export const Default: Story = {
             prefix="13SIM1"
             imageArrayPV="13SIM1:image1:ArrayData"
             enableSettings={false}
+            enableControlPanel={false}
             autoStart
         />
     ),
@@ -42,6 +44,7 @@ export const Default: Story = {
     prefix="13SIM1"
     imageArrayPV="13SIM1:image1:ArrayData"
     enableSettings={false}
+    enableControlPanel={false}
     autoStart
 />`,
                 language: 'tsx',

--- a/src/stories/OphydComponents/CameraContainer.stories.tsx
+++ b/src/stories/OphydComponents/CameraContainer.stories.tsx
@@ -1,0 +1,51 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import CameraContainer from '@/components/Camera/CameraContainer';
+import { beamstopBeamline, simDetectorConfig } from '@/lib/ophyd-sim';
+import { withCameraSim } from '../demos/ophydSimDecorators';
+
+/**
+ * Area-detector viewer: a live image canvas plus Acquire/Pause controls (and an
+ * optional settings panel). It takes a detector `prefix` and streams frames over
+ * the camera socket while subscribing to the detector's control PVs.
+ *
+ * Driven by the `beamstopBeamline` sim's `13SIM1` detector: the `withCameraSim`
+ * decorator supplies both the PV transport and a simulated camera-socket factory,
+ * so the canvas renders live derived frames with no backend. `autoStart` begins
+ * the stream on mount (otherwise press **Acquire**); the settings panel is
+ * disabled to keep the demo focused on the image. The sample code shows only the
+ * component.
+ */
+const meta = {
+    title: 'Ophyd Components/CameraContainer',
+    component: CameraContainer,
+    tags: ['autodocs'],
+    parameters: { layout: 'centered' },
+    decorators: [withCameraSim(beamstopBeamline, simDetectorConfig)],
+} satisfies Meta<typeof CameraContainer>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    render: () => (
+        <CameraContainer
+            prefix="13SIM1"
+            imageArrayPV="13SIM1:image1:ArrayData"
+            enableSettings={false}
+            autoStart
+        />
+    ),
+    parameters: {
+        docs: {
+            source: {
+                code: `<CameraContainer
+    prefix="13SIM1"
+    imageArrayPV="13SIM1:image1:ArrayData"
+    enableSettings={false}
+    autoStart
+/>`,
+                language: 'tsx',
+            },
+        },
+    },
+};

--- a/src/stories/OphydComponents/DeviceControllerBox.stories.tsx
+++ b/src/stories/OphydComponents/DeviceControllerBox.stories.tsx
@@ -1,0 +1,63 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import DeviceControllerBox from '@/components/DeviceControllerBox';
+import useOphydPVSocket from '@/api/ophyd/useOphydPVSocket';
+import { withOphydSim, defaultBeamline } from '@/lib/ophyd-sim';
+
+/**
+ * Single-device controller card (absolute + relative moves, lock). It is a plain
+ * presentational component: you feed it a `device` (and optional readback
+ * `deviceRBV`) plus the `handleSetValueRequest` / `handleLockClick` callbacks.
+ *
+ * You obtain those from `useOphydPVSocket`, the same hook used against a real
+ * IOC. Below, the `defaultBeamline` sim serves `IOC:m1` / `IOC:m1.RBV`, so
+ * moving the box animates the readback live. The sim providers are applied as a
+ * decorator and are omitted from the sample code — the code shows exactly how
+ * you would wire the component to a PV in your own app.
+ */
+const meta = {
+    title: 'Ophyd Components/DeviceControllerBox',
+    component: DeviceControllerBox,
+    tags: ['autodocs'],
+    parameters: { layout: 'centered' },
+    decorators: [withOphydSim(defaultBeamline)],
+} satisfies Meta<typeof DeviceControllerBox>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+function ConnectedBox() {
+    const { devices, handleSetValueRequest, toggleDeviceLock } = useOphydPVSocket([
+        'IOC:m1',
+        'IOC:m1.RBV',
+    ]);
+    return (
+        <DeviceControllerBox
+            device={devices['IOC:m1']}
+            deviceRBV={devices['IOC:m1.RBV']}
+            handleSetValueRequest={handleSetValueRequest}
+            handleLockClick={toggleDeviceLock}
+        />
+    );
+}
+
+export const Default: Story = {
+    render: () => <ConnectedBox />,
+    parameters: {
+        docs: {
+            source: {
+                code: `const { devices, handleSetValueRequest, toggleDeviceLock } = useOphydPVSocket([
+    'IOC:m1',
+    'IOC:m1.RBV',
+]);
+
+<DeviceControllerBox
+    device={devices['IOC:m1']}
+    deviceRBV={devices['IOC:m1.RBV']}
+    handleSetValueRequest={handleSetValueRequest}
+    handleLockClick={toggleDeviceLock}
+/>`,
+                language: 'tsx',
+            },
+        },
+    },
+};

--- a/src/stories/OphydComponents/EnergyVsCurrentPlotPV.stories.tsx
+++ b/src/stories/OphydComponents/EnergyVsCurrentPlotPV.stories.tsx
@@ -1,0 +1,49 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import EnergyVsCurrentPlotPV from '@/features/EnergyVsCurrentPlotPV';
+import { withOphydSim, beamstopBeamline } from '@/lib/ophyd-sim';
+
+/**
+ * "Beam Energy vs Beamstop Current" plot. It overlays a live *measured* trace
+ * (samples accumulated as the energy PV sweeps) against the noise-free *expected*
+ * curve from `beamstopCurrentModel` at the current beamstop position. All four
+ * inputs are supplied as PV names and read with `useOphydPVSocket`.
+ *
+ * Backed by the `beamstopBeamline` sim. To see the measured points populate,
+ * open the **Beamstop** story (or drive `bl531:mono_energy_eV`) so the energy
+ * changes over time; here the expected curve is shown at the default position.
+ */
+const meta = {
+    title: 'Ophyd Components/EnergyVsCurrentPlotPV',
+    component: EnergyVsCurrentPlotPV,
+    tags: ['autodocs'],
+    parameters: { layout: 'centered' },
+    decorators: [withOphydSim(beamstopBeamline)],
+} satisfies Meta<typeof EnergyVsCurrentPlotPV>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    render: () => (
+        <EnergyVsCurrentPlotPV
+            energyPv="bl531:mono_energy_eV"
+            currentPv="bl201-beamstop:current"
+            beamstopXRbvPv="bl531_xps2:beamstop_x_mm.RBV"
+            beamstopYRbvPv="bl531_xps2:beamstop_y_mm.RBV"
+            className="w-[720px]"
+        />
+    ),
+    parameters: {
+        docs: {
+            source: {
+                code: `<EnergyVsCurrentPlotPV
+    energyPv="bl531:mono_energy_eV"
+    currentPv="bl201-beamstop:current"
+    beamstopXRbvPv="bl531_xps2:beamstop_x_mm.RBV"
+    beamstopYRbvPv="bl531_xps2:beamstop_y_mm.RBV"
+/>`,
+                language: 'tsx',
+            },
+        },
+    },
+};

--- a/src/stories/OphydComponents/Hexapod.stories.tsx
+++ b/src/stories/OphydComponents/Hexapod.stories.tsx
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import Hexapod from '@/components/Hexapod/Hexapod';
+import { withOphydSim, hexapodBeamline } from '@/lib/ophyd-sim';
+
+/**
+ * Six-axis Symetrie hexapod widget (controller + live position plot). `Hexapod`
+ * derives its PV names from `prefix` (default `SYM:HEX01`) and talks to them over
+ * `useOphydSocket`.
+ *
+ * The `hexapodBeamline` sim scenario seeds that exact device, so the readbacks
+ * and moves below are live. Enter target positions in the controller and press
+ * the move command to watch the axes animate. Only `<Hexapod />` shows in the
+ * code — the sim providers are a decorator.
+ */
+const meta = {
+    title: 'Ophyd Components/Hexapod',
+    component: Hexapod,
+    tags: ['autodocs'],
+    parameters: { layout: 'centered' },
+    decorators: [withOphydSim(hexapodBeamline)],
+} satisfies Meta<typeof Hexapod>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    render: () => <Hexapod prefix="SYM:HEX01" />,
+    parameters: {
+        docs: { source: { code: '<Hexapod prefix="SYM:HEX01" />', language: 'tsx' } },
+    },
+};

--- a/src/stories/OphydComponents/Shutter.stories.tsx
+++ b/src/stories/OphydComponents/Shutter.stories.tsx
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import Shutter from '@/components/Shutter';
+import { withOphydSim, beamstopBeamline } from '@/lib/ophyd-sim';
+
+/**
+ * Beam-shutter control. `Shutter` subscribes to a single analog-output PV via
+ * `useOphydPVSocket` (default `bl531:LJT4:1:AO0`, 0 V = Open / 5 V = Closed) and
+ * writes it from the dropdown.
+ *
+ * Here it is driven by the `beamstopBeamline` ophyd-sim scenario, which seeds
+ * that PV — so opening and closing the shutter below is fully live, no backend
+ * required. Only the `<Shutter />` element is shown in the code below; the sim
+ * providers are applied as a Storybook decorator.
+ */
+const meta = {
+    title: 'Ophyd Components/Shutter',
+    component: Shutter,
+    tags: ['autodocs'],
+    parameters: { layout: 'centered' },
+    decorators: [withOphydSim(beamstopBeamline)],
+} satisfies Meta<typeof Shutter>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    render: () => <Shutter className="w-96" />,
+    parameters: {
+        docs: { source: { code: '<Shutter />', language: 'tsx' } },
+    },
+};

--- a/src/stories/OphydComponents/SignalMonitorPlotOphyd.stories.tsx
+++ b/src/stories/OphydComponents/SignalMonitorPlotOphyd.stories.tsx
@@ -1,0 +1,56 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import SignalMonitorPlotOphyd from '@/components/SignalMonitorPlotOphyd';
+import { withDeviceTransport } from '../demos/ophydSimDecorators';
+import { createMockDeviceTransport } from '../demos/mockDeviceTransport';
+
+/**
+ * Live strip-chart wired by **Ophyd device name** (the device-socket counterpart
+ * of `SignalMonitorPlotPV`). It subscribes with `useOphydDeviceSocket` and plots
+ * the device value on a rolling window.
+ *
+ * Because ophyd-sim serves PVs, not the device socket, a small mock device
+ * transport supplies a live, oscillating `beamstop_current` device here. The
+ * transport is a decorator; the sample code shows only the component.
+ */
+const deviceTransport = createMockDeviceTransport({
+    beamstop_current: {
+        initialValue: 50,
+        units: 'arb.',
+        periodMs: 500,
+        // Gentle oscillation so the plot visibly moves.
+        animate: (t) => 50 + 40 * Math.sin(t / 2),
+    },
+});
+
+const meta = {
+    title: 'Ophyd Components/SignalMonitorPlotOphyd',
+    component: SignalMonitorPlotOphyd,
+    tags: ['autodocs'],
+    parameters: { layout: 'centered' },
+    decorators: [withDeviceTransport(deviceTransport)],
+} satisfies Meta<typeof SignalMonitorPlotOphyd>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    render: () => (
+        <SignalMonitorPlotOphyd
+            deviceName="beamstop_current"
+            className="h-96 w-[640px]"
+            numVisiblePoints={60}
+        />
+    ),
+    parameters: {
+        docs: {
+            source: {
+                code: `<SignalMonitorPlotOphyd
+    deviceName="beamstop_current"
+    className="h-96 w-[640px]"
+    numVisiblePoints={60}
+/>`,
+                language: 'tsx',
+            },
+        },
+    },
+};

--- a/src/stories/OphydComponents/SignalMonitorPlotPV.stories.tsx
+++ b/src/stories/OphydComponents/SignalMonitorPlotPV.stories.tsx
@@ -1,0 +1,47 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import SignalMonitorPlotPV from '@/components/SignalMonitorPlotPV';
+import { withOphydSim, beamstopBeamline } from '@/lib/ophyd-sim';
+
+/**
+ * Live strip-chart for a single EPICS PV. `SignalMonitorPlotPV` takes a `pv`
+ * name, subscribes with `useOphydPVSocket`, and plots each new value on a
+ * rolling time window.
+ *
+ * Driven by the `beamstopBeamline` sim, which exposes the derived diode-current
+ * PV `bl201-beamstop:current` (it updates every 100 ms). The sim providers are a
+ * decorator, so the code below is just the component.
+ */
+const meta = {
+    title: 'Ophyd Components/SignalMonitorPlotPV',
+    component: SignalMonitorPlotPV,
+    tags: ['autodocs'],
+    parameters: { layout: 'centered' },
+    decorators: [withOphydSim(beamstopBeamline)],
+} satisfies Meta<typeof SignalMonitorPlotPV>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    render: () => (
+        <SignalMonitorPlotPV
+            pv="bl201-beamstop:current"
+            className="h-96 w-[640px]"
+            numVisiblePoints={200}
+            tickTextIntervalSeconds={30}
+        />
+    ),
+    parameters: {
+        docs: {
+            source: {
+                code: `<SignalMonitorPlotPV
+    pv="bl201-beamstop:current"
+    className="h-96 w-[640px]"
+    numVisiblePoints={200}
+    tickTextIntervalSeconds={30}
+/>`,
+                language: 'tsx',
+            },
+        },
+    },
+};

--- a/src/stories/OphydComponents/TableDeviceControllerWithRBV.stories.tsx
+++ b/src/stories/OphydComponents/TableDeviceControllerWithRBV.stories.tsx
@@ -1,0 +1,70 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import TableDeviceControllerWithRBV from '@/components/TableDeviceControllerWithRBV';
+import useOphydPVSocket from '@/api/ophyd/useOphydPVSocket';
+import { withOphydSim, beamstopBeamline } from '@/lib/ophyd-sim';
+
+/**
+ * Tabular multi-device controller with a separate readback column. It takes a
+ * `devices` map (setpoints) and a `devicesRBV` map (readbacks) plus the move /
+ * lock / expand callbacks.
+ *
+ * Build both maps from `useOphydPVSocket` — one subscription for the setpoints
+ * and one for the `.RBV` readbacks. The `beamstopBeamline` sim serves the two
+ * beamstop motors below, so each move animates its readback live. The sim
+ * providers are a decorator; the sample code shows only the hook + component.
+ */
+const meta = {
+    title: 'Ophyd Components/TableDeviceControllerWithRBV',
+    component: TableDeviceControllerWithRBV,
+    tags: ['autodocs'],
+    parameters: { layout: 'padded' },
+    decorators: [withOphydSim(beamstopBeamline)],
+} satisfies Meta<typeof TableDeviceControllerWithRBV>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const MOTORS = ['bl531_xps2:beamstop_x_mm', 'bl531_xps2:beamstop_y_mm'];
+const MOTORS_RBV = ['bl531_xps2:beamstop_x_mm.RBV', 'bl531_xps2:beamstop_y_mm.RBV'];
+
+function ConnectedTable() {
+    const { devices, handleSetValueRequest, toggleDeviceLock, toggleExpand } =
+        useOphydPVSocket(MOTORS);
+    const { devices: devicesRBV } = useOphydPVSocket(MOTORS_RBV);
+    return (
+        <TableDeviceControllerWithRBV
+            devices={devices}
+            devicesRBV={devicesRBV}
+            handleSetValueRequest={handleSetValueRequest}
+            toggleDeviceLock={toggleDeviceLock}
+            toggleExpand={toggleExpand}
+            collapsibleRelativeMove
+        />
+    );
+}
+
+export const Default: Story = {
+    render: () => <ConnectedTable />,
+    parameters: {
+        docs: {
+            source: {
+                code: `const MOTORS = ['bl531_xps2:beamstop_x_mm', 'bl531_xps2:beamstop_y_mm'];
+const MOTORS_RBV = ['bl531_xps2:beamstop_x_mm.RBV', 'bl531_xps2:beamstop_y_mm.RBV'];
+
+const { devices, handleSetValueRequest, toggleDeviceLock, toggleExpand } =
+    useOphydPVSocket(MOTORS);
+const { devices: devicesRBV } = useOphydPVSocket(MOTORS_RBV);
+
+<TableDeviceControllerWithRBV
+    devices={devices}
+    devicesRBV={devicesRBV}
+    handleSetValueRequest={handleSetValueRequest}
+    toggleDeviceLock={toggleDeviceLock}
+    toggleExpand={toggleExpand}
+    collapsibleRelativeMove
+/>`,
+                language: 'tsx',
+            },
+        },
+    },
+};

--- a/src/stories/OphydSim.md
+++ b/src/stories/OphydSim.md
@@ -1,0 +1,511 @@
+# Ophyd Sim
+
+A self-contained, browser-side simulator for [Ophyd](https://blueskyproject.io/ophyd/)
+beamline devices. It models EPICS-style PVs — motors, shutters, detectors, and
+derived signals — entirely in-process, so finch's normal Ophyd socket hooks can
+be driven without a real IOC or WebSocket backend. It powers Storybook stories,
+tests, and the [`SimulatedBeamline`](https://github.com/bluesky/finch/blob/main/src/features/SimulatedBeamline/SimulatedBeamline.tsx)
+widget.
+
+The **Live demo** at the top of this page is exactly that: two motor-controller
+components wired to an in-browser sim, with no backend behind them.
+
+Everything is re-exported from the package root ([index.ts](https://github.com/bluesky/finch/blob/main/src/lib/ophyd-sim/index.ts));
+import from `@/lib/ophyd-sim`, never from subfolders.
+
+> This page is the usage / getting-started guide. For the architecture and the
+> internals of the store, scheduler, and dependency graph, see
+> [skills.md](https://github.com/bluesky/finch/blob/main/src/lib/ophyd-sim/skills.md).
+
+---
+
+## Getting started
+
+The bare minimum: build a sim, wrap the tree in the two providers, and render a
+single [`DeviceControllerBox`](https://github.com/bluesky/finch/blob/main/src/components/DeviceControllerBox.tsx) wired to
+a simulated motor. Because `DeviceControllerBox` is a plain presentational
+component, you connect it to the sim through the ordinary
+[`useOphydPVSocket`](https://github.com/bluesky/finch/blob/main/src/api/ophyd/useOphydPVSocket.tsx) hook — the exact same
+hook used against a real IOC.
+
+```tsx
+import { useMemo } from 'react';
+import {
+    OphydSimProvider,
+    createOphydSimTransport,
+    createOphydSim,
+    motor,
+} from '@/lib/ophyd-sim';
+import { OphydTransportProvider } from '@/api/ophyd/OphydTransportProvider';
+import useOphydPVSocket from '@/api/ophyd/useOphydPVSocket';
+import DeviceControllerBox from '@/components/DeviceControllerBox';
+
+// 1. Build a sim. Keep it stable across renders (module scope or useMemo).
+const sim = createOphydSim({
+    devices: [motor({ name: 'IOC:m1', limits: [-10, 10], velocity: 2, units: 'mm' })],
+});
+
+// 2. A leaf that talks to the sim through the normal Ophyd PV hook.
+function MotorControl() {
+    const { devices, handleSetValueRequest, toggleDeviceLock } = useOphydPVSocket([
+        'IOC:m1',
+        'IOC:m1.RBV',
+    ]);
+
+    return (
+        <DeviceControllerBox
+            device={devices['IOC:m1']}
+            deviceRBV={devices['IOC:m1.RBV']}
+            handleSetValueRequest={handleSetValueRequest}
+            handleLockClick={toggleDeviceLock}
+        />
+    );
+}
+
+// 3. Wrap the tree: OphydSimProvider starts/stops the tick loop;
+//    OphydTransportProvider routes the PV hooks at the sim instead of a WebSocket.
+export function Example() {
+    const transport = useMemo(() => createOphydSimTransport(sim), []);
+    return (
+        <OphydSimProvider sim={sim}>
+            <OphydTransportProvider transport={transport}>
+                <MotorControl />
+            </OphydTransportProvider>
+        </OphydSimProvider>
+    );
+}
+```
+
+Moving the motor from the box animates `IOC:m1.RBV` toward the setpoint and the
+readback ticks live — no backend involved.
+
+**In Storybook**, skip the boilerplate with the `withOphydSim` decorator, which
+mounts both providers for you:
+
+```tsx
+import { withOphydSim, defaultBeamline } from '@/lib/ophyd-sim';
+
+export const decorators = [withOphydSim(defaultBeamline)];
+```
+
+---
+
+## Device catalog
+
+Every device is a **factory** you drop into the `devices` array of
+`createOphydSim`. Below is a comprehensive example of each supported type.
+
+### Signal
+
+A scalar PV. It can be a static literal, a periodically-recomputed function, a
+value derived from other PVs, or any combination. Signals are **read-only by
+default** — pass `writeAccess: true` to make them writable.
+
+```ts
+import { createOphydSim, signal, randomNoise } from '@/lib/ophyd-sim';
+
+createOphydSim({
+    devices: [
+        // Static, read-only scalar.
+        signal({ name: 'IOC:temperature', initialValue: 21.5, units: 'C' }),
+
+        // Writable enum (In / Out), used as a control input for other devices.
+        signal({
+            name: 'IOC:bs',
+            initialValue: 0,
+            writeAccess: true,
+            enumStrs: ['Out', 'In'],
+        }),
+
+        // Periodic signal: recomputes every 100 ms with fresh noise.
+        signal({
+            name: 'IOC:pressure',
+            units: 'mbar',
+            periodMs: 100,
+            value: ({ random }) => 1000 + randomNoise({ random, sigma: 3 }),
+        }),
+    ],
+});
+```
+
+Key `SignalOptions`: `initialValue`, `value` (literal or `(ctx) => value`),
+`dependsOn`, `periodMs`, `units`, `limits`, `writeAccess`, `precision`,
+`enumStrs`. (See [signal.ts](https://github.com/bluesky/finch/blob/main/src/lib/ophyd-sim/devices/signal.ts).)
+
+### Motor
+
+A linear-velocity motor. One factory seeds **three PVs** that share a single
+motion state:
+
+| PV | Meaning |
+| --- | --- |
+| `name` | setpoint (writable; clamps into `limits`) |
+| `name.RBV` | readback — animates toward the setpoint at `velocity` units/s |
+| `name.MOVN` | moving flag — `1` while moving, `0` once settled |
+
+```ts
+import { createOphydSim, motor } from '@/lib/ophyd-sim';
+
+createOphydSim({
+    devices: [
+        motor({
+            name: 'IOC:m1',
+            initialPosition: 0,
+            velocity: 2, // units per second
+            limits: [-10, 10], // soft limits clamp setpoint writes
+            units: 'mm',
+            // epsilon: 1e-4,          // settle tolerance (optional)
+            // readbackName: 'IOC:m1.RBV',  // override defaults (optional)
+            // movingName: 'IOC:m1.MOVN',
+        }),
+    ],
+});
+```
+
+Writing the setpoint (`sim.set('IOC:m1', 5)`) sets `MOVN=1` and advances `.RBV`
+by `velocity * dt` each tick until it lands within `epsilon`, then snaps and
+clears `MOVN`. (See [motor.ts](https://github.com/bluesky/finch/blob/main/src/lib/ophyd-sim/devices/motor.ts).)
+
+### Detector
+
+A simulated area detector. Unlike single-value devices, a detector seeds a
+**cluster** of standard Area-Detector PVs from one `prefix` — `cam1:SizeX`,
+`cam1:SizeY`, `cam1:MinX`, `cam1:MinY`, `cam1:ColorMode`, `cam1:DataType`,
+`cam1:Acquire`, and the image `image1:Mode`. The image pixels themselves are not
+a PV; they stream over the camera socket — but their scalar
+parameters (opacity, overlay positions) are PVs that other devices can drive.
+
+```ts
+import { createOphydSim, detector } from '@/lib/ophyd-sim';
+
+createOphydSim({
+    devices: [
+        detector({
+            prefix: '13SIM1',
+            image: {
+                mode: 'image_file', // or 'noisy' for random-noise frames
+                sizeX: 1024,
+                sizeY: 1024,
+                file: '/images/diffraction.png',
+                // files: ['/f0.png', '/f1.png'],  // round-robin per frame (optional)
+                overlays: [
+                    {
+                        file: '/images/beamstop-dot.png',
+                        width: 32,
+                        height: 32,
+                        x: 512, // center in pixels (fallback if unbound)
+                        y: 512,
+                    },
+                ],
+            },
+            // Derived image parameters other devices drive — see next section.
+            modulations: [],
+        }),
+    ],
+});
+```
+
+Detectors are usually loaded from JSON — see
+[simDetector.json](https://github.com/bluesky/finch/blob/main/src/lib/ophyd-sim/scenarios/simDetector.json) and `simDetectorConfig`. To render
+frames to a canvas, pair the detector with
+`createSimDetectorCameraSocketFactory` (see [The camera socket](#the-camera-socket)).
+(See [detector.ts](https://github.com/bluesky/finch/blob/main/src/lib/ophyd-sim/devices/detector.ts).)
+
+### Bonus: shutter & hexapod
+
+Two higher-level factories cover common beamline hardware:
+
+```ts
+import { createOphydSim, shutter, hexapod } from '@/lib/ophyd-sim';
+
+createOphydSim({
+    devices: [
+        // Beam shutter: one analog-output PV, 0 V open / 5 V closed. Defaults open.
+        shutter({ name: 'bl531:LJT4:1:AO0' /*, initial: 'closed' */ }),
+
+        // Symetrie six-axis hexapod: seeds *_RBV readbacks, MOVE_PTP setpoints,
+        // and the MOVE_PTP execute/STOP command PVs under the given prefix.
+        hexapod({ prefix: 'SYM:HEX01', translationVelocity: 4, rotationVelocity: 2 }),
+    ],
+});
+```
+
+See [shutter.ts](https://github.com/bluesky/finch/blob/main/src/lib/ophyd-sim/devices/shutter.ts) and [hexapod.ts](https://github.com/bluesky/finch/blob/main/src/lib/ophyd-sim/devices/hexapod.ts) for
+the full PV maps and options.
+
+---
+
+## Creating connected devices
+
+The whole point of the simulator is that one device can react to the **current
+value of another**. Devices never reference each other directly — they read and
+write the same shared state. A device becomes "connected" by listing the PVs it
+cares about in `dependsOn`; its `compute` function then re-runs, in dependency
+order, whenever any of those inputs change.
+
+Inside `compute(ctx)` you get a `SimValueContext`:
+
+- `ctx.get.number(pv)` / `.boolean(pv)` / `.string(pv)` / `.value(pv)` — read inputs
+- `ctx.time`, `ctx.dt` — current time (ms) and elapsed seconds since last tick
+- `ctx.random()` — the sim's random source (override `random` in `createOphydSim`
+  for deterministic tests)
+
+> `compute` also runs **once at registration** to seed an initial value, so guard
+> against inputs that may not be seeded yet. Order matters: a dependency must be
+> registered *before* the device that depends on it. A `compute` that throws is
+> logged and skipped, not fatal.
+
+### Example 1 — a signal derived from a motor and a control input
+
+A diode reading that peaks when a motor's readback is near 2, is attenuated when
+a beamstop is inserted, and carries measurement noise:
+
+```ts
+import { createOphydSim, motor, signal, gaussian, randomNoise } from '@/lib/ophyd-sim';
+
+createOphydSim({
+    devices: [
+        motor({ name: 'IOC:m1', limits: [-10, 10], velocity: 1, units: 'mm' }),
+        signal({ name: 'IOC:bs', initialValue: 0, writeAccess: true, enumStrs: ['Out', 'In'] }),
+
+        // I0 recomputes whenever the motor readback OR the beamstop changes,
+        // and also every 100 ms so the noise keeps moving.
+        signal({
+            name: 'I0',
+            units: 'arb.',
+            periodMs: 100,
+            dependsOn: ['IOC:m1.RBV', 'IOC:bs'], // <-- the connection
+            value: ({ get, random }) => {
+                const beam = 1000 * gaussian({ x: get.number('IOC:m1.RBV'), center: 2, sigma: 0.5 });
+                const attenuated = get.boolean('IOC:bs') ? beam * 0.01 : beam;
+                return attenuated + randomNoise({ random, sigma: 5 });
+            },
+        }),
+    ],
+});
+```
+
+Now `sim.set('IOC:m1', 2)` makes `I0` climb as the readback approaches the peak,
+and `sim.set('IOC:bs', 1)` drops it ~99% — all automatically. This is exactly the
+[`defaultBeamline`](https://github.com/bluesky/finch/blob/main/src/lib/ophyd-sim/scenarios/defaultBeamline.ts) scenario, and the
+same coupling drives the diode readout under the Live demo above.
+
+### Example 2 — chaining multiple derived signals
+
+`dependsOn` targets can themselves be derived PVs, so you can build a coupling
+chain. Here energy drives a Bragg angle, which drives a beam position:
+
+```ts
+import { createOphydSim, motor, signal, braggAngle } from '@/lib/ophyd-sim';
+
+createOphydSim({
+    devices: [
+        motor({ name: 'bl:mono_energy_eV', limits: [2000, 7000], velocity: 100, initialPosition: 4500 }),
+
+        // theta derived from energy.
+        signal({
+            name: 'bl:bragg_deg',
+            units: 'deg',
+            dependsOn: ['bl:mono_energy_eV.RBV'],
+            value: ({ get }) => braggAngle({ energyEV: get.number('bl:mono_energy_eV.RBV') }),
+        }),
+
+        // beam Y derived from theta — a second-order dependency.
+        signal({
+            name: 'bl:beam_y_mm',
+            units: 'mm',
+            dependsOn: ['bl:bragg_deg'],
+            value: ({ get }) => 4 * Math.cos((get.number('bl:bragg_deg') * Math.PI) / 180),
+        }),
+    ],
+});
+```
+
+### Example 3 — a detector image driven by another device
+
+A detector `modulation` is just a derived PV under the hood: it binds an image
+parameter (e.g. `image1:Opacity`) to a source PV via a linear-clamped map. Here
+beam energy dims the rendered image, and a beamstop motor's readback drives an
+overlay marker's position:
+
+```ts
+detector({
+    prefix: '13SIM1',
+    image: {
+        mode: 'image_file',
+        sizeX: 1024,
+        sizeY: 1024,
+        file: '/images/diffraction.png',
+        overlays: [
+            {
+                file: '/images/beamstop-dot.png',
+                width: 32,
+                height: 32,
+                x: 512,
+                y: 512,
+                // Bind the marker's X to a motor readback: -10..10 mm -> 0..1024 px.
+                positionX: {
+                    source: 'bl531_xps2:beamstop_x_mm.RBV',
+                    from: { in: -10, out: 0 },
+                    to: { in: 10, out: 1024 },
+                },
+            },
+        ],
+    },
+    // Energy 2000..7000 eV maps to image opacity 1.0..0.2.
+    modulations: [
+        {
+            source: 'bl:mono_energy_eV.RBV',
+            effect: 'opacity',
+            from: { in: 2000, out: 1.0 },
+            to: { in: 7000, out: 0.2 },
+        },
+    ],
+});
+```
+
+The flagship [`beamstopBeamline`](https://github.com/bluesky/finch/blob/main/src/lib/ophyd-sim/scenarios/beamstopBeamline.ts) scenario wires
+all of these patterns together (energy → Bragg → beam Y → 2D-Gaussian diode
+current, gated by a shutter). It's worth reading as a full worked example — the
+physics is documented in [skills.md](https://github.com/bluesky/finch/blob/main/src/lib/ophyd-sim/skills.md).
+
+---
+
+## How ophyd-sim works
+
+A sim is a bag of named PVs over shared state, plus two update mechanisms:
+
+- **Ticks** — a periodic loop (`tickMs`, ~33 ms ≈ 30 Hz) that advances time-based
+  devices: motor motion, periodic signals.
+- **Derived signals** — values with a `dependsOn` list that recompute, in
+  dependency order, whenever an input PV changes.
+
+The React app never talks to the sim directly. It uses its ordinary Ophyd PV
+hooks, which read a **transport** from context. In production that transport is a
+WebSocket to a real IOC; `createOphydSimTransport` swaps in an implementation of
+the same interface that reads and writes the in-memory sim instead.
+
+```text
+React component (e.g. DeviceControllerBox)
+        |  handleSetValueRequest / devices
+        v
+useOphydPVSocket(['IOC:m1', ...])
+        |  reads transport via useOphydPVTransport()
+        v
+OphydTransportProvider  ── production ──▶  WebSocket → real IOC
+        |
+        └─ simulation ──▶ createOphydSimTransport(sim)
+                                |  subscribe / set / unsubscribe / refresh
+                                v
+                          OphydSim instance
+                          ├─ SimState store (PV values + metadata)
+                          ├─ DependencyGraph (derived recompute)
+                          ├─ Scheduler (tick loop, tickMs)
+                          └─ Device factories (motor / signal / detector / …)
+
+OphydSimProvider ── start() on mount / stop() on unmount ──▶ Scheduler
+```
+
+The two providers have distinct jobs:
+
+- **`OphydSimProvider`** owns the sim's lifecycle — it calls `sim.start()` on
+  mount and `sim.stop()` on unmount, and exposes the sim to the sim-specific
+  hooks (`useSimSignal`, `useSimSet`).
+- **`OphydTransportProvider`** installs the transport into context so the
+  *generic* Ophyd hooks resolve to the sim instead of a WebSocket. (It can also
+  wrap the sim with `fallbackToReal` so descendants fail over to a real backend
+  if the override reports an error.)
+
+---
+
+## When & how ophyd-sim kicks in
+
+ophyd-sim engages purely through the **transport seam**. finch's Ophyd hooks
+never open a socket themselves — they pull a transport out of React context via
+`useOphydPVTransport()`. Whichever transport is in context wins:
+
+- **No `OphydTransportProvider`, or no override** → the hook lazily constructs a
+  real WebSocket transport pointed at the configured backend. (Production.)
+- **An `OphydTransportProvider` supplies `transport={createOphydSimTransport(sim)}`**
+  → every descendant PV hook is transparently driven by the sim. Nothing else in
+  the component changes; the same code runs against sim or IOC. (Storybook, tests,
+  `SimulatedBeamline`.)
+
+### What the sim transport speaks
+
+`createOphydSimTransport` implements the `OphydPVTransport` wire protocol. The
+hooks exercise it through these actions (see [createOphydSimTransport.ts](https://github.com/bluesky/finch/blob/main/src/lib/ophyd-sim/transport/createOphydSimTransport.ts)):
+
+| Action sent by a hook | What the sim transport does |
+| --- | --- |
+| `subscribe` / `subscribeSafely` / `subscribeReadOnly` | Emits a synthesized `meta` message (so the device shows connected) then streams every value change for that PV |
+| `set` | Writes to the sim (`sim.set`), triggering derived recompute + motor motion |
+| `unsubscribe` | Drops the most recent listener for that PV |
+| `refresh` | Replays the latest value of every active subscription |
+| `onStatus` | Reports `'open'` synchronously — there's no real handshake |
+
+### The Ophyd hooks that use the transport
+
+These are the specific hooks that resolve their transport from context and are
+therefore driven by ophyd-sim when a sim transport is provided:
+
+- **[`useOphydPVSocket(pvs, wsUrl?)`](https://github.com/bluesky/finch/blob/main/src/api/ophyd/useOphydPVSocket.tsx)** — the
+  primary PV-socket hook. Reads its transport via `useOphydPVTransport()`, sends
+  `subscribe`/`set`/`unsubscribe`/`refresh`, and returns `{ devices,
+  handleSetValueRequest, toggleDeviceLock, toggleExpand }`. **This is the hook the
+  sim is built to serve** — and the one the Live demo above uses.
+- **[`useOphydSocket(pvs, wsUrl?)`](https://github.com/bluesky/finch/blob/main/src/api/ophyd/useOphydSocket.ts)** — legacy
+  alias kept for backwards compatibility; delegates to `useOphydPVSocket`, so it
+  is sim-driven too.
+
+The React-native sim hooks in [`react/`](https://github.com/bluesky/finch/blob/main/src/lib/ophyd-sim/react/) talk to the sim **directly**
+(not through the transport), and are handy when you're already inside an
+`OphydSimProvider` and don't need the full PV-socket abstraction:
+
+- **`useSimSignal(pv)`** — subscribe to one PV's value; re-renders on change.
+- **`useSimSet()`** — returns a stable `(pv, value) => void` writer.
+- **`useOphydSim()` / `useOphydSimOptional()`** — grab the sim instance itself.
+
+### The camera socket
+
+Detector **image frames** don't travel over the PV transport — they stream over a
+separate camera-socket seam. `CameraCanvas` reads its factory from
+`useCameraSocketFactory()`, which `OphydTransportProvider` supplies via its
+`cameraSocketFactory` prop. Pass
+`createSimDetectorCameraSocketFactory(sim, detectorConfig)` there to render a
+detector's live derived state (opacity, overlay positions) to canvas frames — see
+[`SimulatedBeamline`](https://github.com/bluesky/finch/blob/main/src/features/SimulatedBeamline/SimulatedBeamline.tsx) for
+the full wiring.
+
+### Not backed by ophyd-sim
+
+- **[`useOphydDeviceSocket`](https://github.com/bluesky/finch/blob/main/src/api/ophyd/useOphydDeviceSocket.ts)** uses the
+  separate *device*-socket transport. `createOphydSimTransport` is a *PV*
+  transport only, so this hook is not driven by ophyd-sim (it falls back to the
+  real device backend unless you supply a `deviceTransport` override).
+- **[`useSimOphydPVSocket`](https://github.com/bluesky/finch/blob/main/src/api/ophyd/useSimOphydPVSocket.tsx)** is an older,
+  standalone mock (`sineSignal` / `noisySignal` keywords) that is **unrelated** to
+  this package — it doesn't use a transport at all. Prefer `useOphydPVSocket` +
+  a sim transport for new work.
+
+### Driving the sim without React
+
+The transport and providers are optional. You can drive a sim directly — useful
+in tests, where you skip the real loop and step time by hand:
+
+```ts
+const sim = createOphydSim({ devices: [motor({ name: 'IOC:m1', velocity: 2 })] });
+
+sim.set('IOC:m1', 5); // command a move
+sim.advance(1000); // step 1 s of simulated time (no real timers)
+sim.get('IOC:m1.RBV'); // => 2  (moved velocity * dt)
+
+// or run the real loop:
+sim.start();
+// ... later ...
+sim.stop();
+```
+
+`advance(deltaMs)` runs a single synthetic tick, so motor motion and periodic
+recompute are fully deterministic when you also override `random` and `now` in
+`createOphydSim`.

--- a/src/stories/OphydSim.mdx
+++ b/src/stories/OphydSim.mdx
@@ -1,6 +1,7 @@
 import { Markdown, Meta } from '@storybook/addon-docs/blocks';
 import OphydSimDoc from './OphydSim.md?raw';
 import OphydSimDemo from './demos/OphydSimDemo';
+import EndstationDisplayDemo from './demos/EndstationDisplayDemo';
 
 <Meta title="Documentation/Ophyd Sim" />
 
@@ -9,6 +10,10 @@ import OphydSimDemo from './demos/OphydSimDemo';
 A browser-side simulator for Ophyd beamline devices — motors, shutters,
 detectors, and derived signals — that drives finch's normal Ophyd hooks without
 a real IOC or WebSocket backend.
+
+<div style={{ display: 'flex', justifyContent: 'center', margin: '1rem 0 2rem' }}>
+    <EndstationDisplayDemo />
+</div>
 
 ## Live demo
 

--- a/src/stories/OphydSim.mdx
+++ b/src/stories/OphydSim.mdx
@@ -1,0 +1,31 @@
+import { Markdown, Meta } from '@storybook/addon-docs/blocks';
+import OphydSimDoc from './OphydSim.md?raw';
+import OphydSimDemo from './demos/OphydSimDemo';
+
+<Meta title="Documentation/Ophyd Sim" />
+
+# Ophyd Sim
+
+A browser-side simulator for Ophyd beamline devices — motors, shutters,
+detectors, and derived signals — that drives finch's normal Ophyd hooks without
+a real IOC or WebSocket backend.
+
+## Live demo
+
+The motor-controller components below are wired to an in-browser simulator. Move
+a motor and its readback animates toward the setpoint; nudging <code>demo:m1</code>
+toward 2&nbsp;mm drives the derived diode reading. No backend is involved.
+
+<div
+    style={{
+        padding: '1.5rem',
+        background: '#f8fafc',
+        borderRadius: '8px',
+        border: '1px solid #e2e8f0',
+        margin: '1rem 0 2rem',
+    }}
+>
+    <OphydSimDemo />
+</div>
+
+<Markdown>{OphydSimDoc}</Markdown>

--- a/src/stories/demos/EndstationDisplayDemo.tsx
+++ b/src/stories/demos/EndstationDisplayDemo.tsx
@@ -1,20 +1,58 @@
 import { useMemo } from 'react';
 import { OphydSimProvider, createOphydSimTransport, beamstopBeamline } from '@/lib/ophyd-sim';
 import { OphydTransportProvider } from '@/api/ophyd/OphydTransportProvider';
+import useOphydPVSocket from '@/api/ophyd/useOphydPVSocket';
 import EndstationDisplay from '@/components/EndstationDisplay/EndstationDisplay';
+import TableDeviceControllerWithRBV from '@/components/TableDeviceControllerWithRBV';
+import Shutter from '@/components/Shutter';
+
+/** Writable motors whose readbacks the endstation graphic tracks. */
+const MOVERS = [
+    'bl531_xps2:beamstop_x_mm',
+    'bl531_xps2:beamstop_y_mm',
+    'bl531:sample_x_mm',
+    'bl531:sample_y_mm',
+];
+const MOVERS_RBV = MOVERS.map((pv) => `${pv}.RBV`);
+
+/** Live controls that drive the graphic: shutter + beamstop/sample X-Y motors. */
+function EndstationControls() {
+    const { devices, handleSetValueRequest, toggleDeviceLock, toggleExpand } =
+        useOphydPVSocket(MOVERS);
+    const { devices: devicesRBV } = useOphydPVSocket(MOVERS_RBV);
+    return (
+        <div className="flex w-full max-w-[600px] flex-col gap-4">
+            {/* Shutter open/closed blocks or passes the beam in the graphic above. */}
+            <Shutter className="w-full" />
+            {/* Moving the beamstop or sample motors slides the matching marker. */}
+            <TableDeviceControllerWithRBV
+                devices={devices}
+                devicesRBV={devicesRBV}
+                handleSetValueRequest={handleSetValueRequest}
+                toggleDeviceLock={toggleDeviceLock}
+                toggleExpand={toggleExpand}
+                collapsibleRelativeMove
+            />
+        </div>
+    );
+}
 
 /**
- * The endstation / beamstop graphic (`EndstationDisplay`) wired to the
- * `beamstopBeamline` sim, self-contained for embedding at the top of the
- * "Ophyd Sim" documentation page. The layered SVG shows the beam, shutter, and
- * beamstop marker driven by live sim state — no backend required.
+ * The endstation / beamstop graphic (`EndstationDisplay`) plus the live controls
+ * that drive it, wired to the `beamstopBeamline` sim and self-contained for
+ * embedding at the top of the "Ophyd Sim" documentation page. The graphic and
+ * controls share one sim, so opening the shutter or moving the beamstop / sample
+ * motors updates the layered SVG live — no backend required.
  */
 export default function EndstationDisplayDemo() {
     const transport = useMemo(() => createOphydSimTransport(beamstopBeamline), []);
     return (
         <OphydSimProvider sim={beamstopBeamline}>
             <OphydTransportProvider transport={transport}>
-                <EndstationDisplay className="w-full max-w-[600px] rounded" />
+                <div className="flex flex-col items-center gap-4">
+                    <EndstationDisplay className="w-full max-w-[600px] rounded" />
+                    <EndstationControls />
+                </div>
             </OphydTransportProvider>
         </OphydSimProvider>
     );

--- a/src/stories/demos/EndstationDisplayDemo.tsx
+++ b/src/stories/demos/EndstationDisplayDemo.tsx
@@ -1,0 +1,21 @@
+import { useMemo } from 'react';
+import { OphydSimProvider, createOphydSimTransport, beamstopBeamline } from '@/lib/ophyd-sim';
+import { OphydTransportProvider } from '@/api/ophyd/OphydTransportProvider';
+import EndstationDisplay from '@/components/EndstationDisplay/EndstationDisplay';
+
+/**
+ * The endstation / beamstop graphic (`EndstationDisplay`) wired to the
+ * `beamstopBeamline` sim, self-contained for embedding at the top of the
+ * "Ophyd Sim" documentation page. The layered SVG shows the beam, shutter, and
+ * beamstop marker driven by live sim state — no backend required.
+ */
+export default function EndstationDisplayDemo() {
+    const transport = useMemo(() => createOphydSimTransport(beamstopBeamline), []);
+    return (
+        <OphydSimProvider sim={beamstopBeamline}>
+            <OphydTransportProvider transport={transport}>
+                <EndstationDisplay className="w-full max-w-[600px] rounded" />
+            </OphydTransportProvider>
+        </OphydSimProvider>
+    );
+}

--- a/src/stories/demos/OphydSimDemo.tsx
+++ b/src/stories/demos/OphydSimDemo.tsx
@@ -1,0 +1,112 @@
+import { useMemo } from 'react';
+import {
+    OphydSimProvider,
+    createOphydSim,
+    createOphydSimTransport,
+    motor,
+    signal,
+    gaussian,
+    randomNoise,
+    useSimSignal,
+} from '@/lib/ophyd-sim';
+import { OphydTransportProvider } from '@/api/ophyd/OphydTransportProvider';
+import useOphydPVSocket from '@/api/ophyd/useOphydPVSocket';
+import DeviceControllerBox from '@/components/DeviceControllerBox';
+import TableDeviceControllerWithRBV from '@/components/TableDeviceControllerWithRBV';
+
+/**
+ * Live, self-contained demo embedded in the "Ophyd Sim" documentation page.
+ *
+ * It builds its own simulator (two motors plus a diode signal that peaks when
+ * `demo:m1` is near 2 mm) and mounts the same two providers the rest of finch
+ * uses — so the motor-controller components below are driven entirely in the
+ * browser, no IOC or WebSocket backend required. Moving a motor animates its
+ * readback and, for `demo:m1`, updates the derived diode reading live.
+ */
+const demoSim = createOphydSim({
+    devices: [
+        motor({ name: 'demo:m1', initialPosition: 0, velocity: 2, limits: [-10, 10], units: 'mm' }),
+        motor({
+            name: 'demo:m2',
+            initialPosition: -3,
+            velocity: 4,
+            limits: [-10, 10],
+            units: 'mm',
+        }),
+        // Diode current, peaked when demo:m1 is near 2 mm, with measurement noise.
+        signal({
+            name: 'demo:I0',
+            units: 'arb.',
+            periodMs: 100,
+            dependsOn: ['demo:m1.RBV'],
+            value: ({ get, random }) =>
+                1000 * gaussian({ x: get.number('demo:m1.RBV'), center: 2, sigma: 0.5 }) +
+                randomNoise({ random, sigma: 5 }),
+        }),
+    ],
+});
+
+const SETPOINTS = ['demo:m1', 'demo:m2'];
+const READBACKS = ['demo:m1.RBV', 'demo:m2.RBV'];
+
+/** Small readout of the derived diode signal, updated straight from the sim. */
+function DiodeReadout() {
+    const value = useSimSignal('demo:I0');
+    return (
+        <p style={{ fontSize: '0.85rem', color: '#64748b', margin: 0 }}>
+            Derived diode <code>demo:I0</code>:{' '}
+            <strong>{typeof value === 'number' ? value.toFixed(1) : '—'}</strong> arb. — climbs as{' '}
+            <code>demo:m1</code> approaches 2&nbsp;mm.
+        </p>
+    );
+}
+
+function DemoContent() {
+    const { devices, handleSetValueRequest, toggleDeviceLock, toggleExpand } =
+        useOphydPVSocket(SETPOINTS);
+    const { devices: devicesRBV } = useOphydPVSocket(READBACKS);
+
+    return (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '1.5rem', maxWidth: '640px' }}>
+            <div>
+                <p style={{ fontWeight: 600, marginBottom: '0.5rem' }}>
+                    Motor controller — <code>demo:m1</code> (DeviceControllerBox)
+                </p>
+                <DeviceControllerBox
+                    device={devices['demo:m1']}
+                    deviceRBV={devicesRBV['demo:m1.RBV']}
+                    handleSetValueRequest={handleSetValueRequest}
+                    handleLockClick={toggleDeviceLock}
+                />
+                <div style={{ marginTop: '0.5rem' }}>
+                    <DiodeReadout />
+                </div>
+            </div>
+            <div>
+                <p style={{ fontWeight: 600, marginBottom: '0.5rem' }}>
+                    Motor table — <code>demo:m1</code> + <code>demo:m2</code>{' '}
+                    (TableDeviceControllerWithRBV)
+                </p>
+                <TableDeviceControllerWithRBV
+                    devices={devices}
+                    devicesRBV={devicesRBV}
+                    handleSetValueRequest={handleSetValueRequest}
+                    toggleDeviceLock={toggleDeviceLock}
+                    toggleExpand={toggleExpand}
+                    collapsibleRelativeMove
+                />
+            </div>
+        </div>
+    );
+}
+
+export default function OphydSimDemo() {
+    const transport = useMemo(() => createOphydSimTransport(demoSim), []);
+    return (
+        <OphydSimProvider sim={demoSim}>
+            <OphydTransportProvider transport={transport}>
+                <DemoContent />
+            </OphydTransportProvider>
+        </OphydSimProvider>
+    );
+}

--- a/src/stories/demos/mockDeviceTransport.ts
+++ b/src/stories/demos/mockDeviceTransport.ts
@@ -1,0 +1,121 @@
+import type {
+    OphydDeviceTransport,
+    OphydDeviceMessageListener,
+} from '@/api/ophyd/transport/deviceTypes';
+import type { MetaUpdateResponse, ValueUpdateResponse } from '@/api/ophyd/ophydDeviceSocketTypes';
+import type { OphydTransportStatus } from '@/api/ophyd/transport/types';
+
+/**
+ * Per-device configuration for {@link createMockDeviceTransport}.
+ *
+ * ophyd-sim only implements a *PV* transport, so the device-socket components
+ * (`BeamEnergyOphyd`, `SignalMonitorPlotOphyd`) can't be driven by it. This tiny
+ * in-memory transport stands in for a device-socket backend in Storybook: it
+ * reports every configured device as connected, answers `set` writes, and — when
+ * `animate` is given — streams a live, changing value so plots move.
+ */
+export type MockDeviceConfig = {
+    /** Value emitted on subscribe (and the starting point for `animate`). */
+    initialValue: number;
+    units?: string;
+    min?: number;
+    max?: number;
+    /** Whether the device reports `write_access`. Defaults to false. */
+    writable?: boolean;
+    /**
+     * When set, the value is recomputed every `periodMs` from the elapsed time
+     * (seconds) and the previous value, and a fresh value update is emitted.
+     */
+    animate?: (elapsedSeconds: number, current: number) => number;
+    /** Emit interval for `animate`, in ms. Defaults to 500. */
+    periodMs?: number;
+};
+
+/** Build a mock {@link OphydDeviceTransport} serving the given devices. */
+export function createMockDeviceTransport(
+    devices: Record<string, MockDeviceConfig>,
+): OphydDeviceTransport {
+    const listeners = new Set<OphydDeviceMessageListener>();
+    const values: Record<string, number> = {};
+    const timers: Record<string, ReturnType<typeof setInterval>> = {};
+    const start = Date.now();
+
+    for (const [name, cfg] of Object.entries(devices)) values[name] = cfg.initialValue;
+
+    const emit = (msg: ValueUpdateResponse | MetaUpdateResponse) =>
+        listeners.forEach((listener) => listener(msg));
+
+    const valueMessage = (name: string): ValueUpdateResponse => ({
+        device: name,
+        value: values[name],
+        timestamp: Date.now() / 1000,
+        connected: true,
+        read_access: true,
+        write_access: devices[name].writable ?? false,
+    });
+
+    const metaMessage = (name: string): MetaUpdateResponse => {
+        const cfg = devices[name];
+        return {
+            ...valueMessage(name),
+            sub_type: 'meta',
+            status: 0,
+            severity: 0,
+            precision: 3,
+            setpoint_timestamp: null,
+            setpoint_status: null,
+            setpoint_severity: null,
+            lower_ctrl_limit: cfg.min ?? null,
+            upper_ctrl_limit: cfg.max ?? null,
+            units: cfg.units ?? '',
+            enum_strs: null,
+            setpoint_precision: null,
+        };
+    };
+
+    return {
+        send(message) {
+            const name = 'device' in message ? message.device : undefined;
+            if (!name || !(name in values)) return;
+
+            if (
+                message.action === 'subscribe' ||
+                message.action === 'subscribeSafely' ||
+                message.action === 'subscribeReadOnly'
+            ) {
+                // Meta first so the device shows connected, then the value.
+                emit(metaMessage(name));
+                emit(valueMessage(name));
+                const cfg = devices[name];
+                if (cfg.animate && !timers[name]) {
+                    timers[name] = setInterval(() => {
+                        values[name] = cfg.animate!((Date.now() - start) / 1000, values[name]);
+                        emit(valueMessage(name));
+                    }, cfg.periodMs ?? 500);
+                }
+            } else if (message.action === 'set') {
+                values[name] = Number(message.value);
+                emit(valueMessage(name));
+            } else if (message.action === 'unsubscribe') {
+                if (timers[name]) {
+                    clearInterval(timers[name]);
+                    delete timers[name];
+                }
+            }
+        },
+        onMessage(listener) {
+            listeners.add(listener);
+            return () => {
+                listeners.delete(listener);
+            };
+        },
+        onStatus(listener) {
+            listener('open' satisfies OphydTransportStatus);
+            return () => {};
+        },
+        close() {
+            Object.values(timers).forEach(clearInterval);
+            listeners.clear();
+        },
+    };
+}

--- a/src/stories/demos/ophydSimDecorators.tsx
+++ b/src/stories/demos/ophydSimDecorators.tsx
@@ -1,0 +1,52 @@
+import type { ReactNode } from 'react';
+import type { OphydSim, DetectorConfig, CameraSocketFactory } from '@/lib/ophyd-sim';
+import {
+    OphydSimProvider,
+    createOphydSimTransport,
+    createSimDetectorCameraSocketFactory,
+} from '@/lib/ophyd-sim';
+import { OphydTransportProvider } from '@/api/ophyd/OphydTransportProvider';
+import type { OphydDeviceTransport } from '@/api/ophyd/transport/deviceTypes';
+
+type Decorator = (Story: () => ReactNode) => ReactNode;
+
+/**
+ * Like `withOphydSim`, but also wires a simulated camera-socket factory so
+ * `CameraCanvas` / `CameraContainer` render live frames from the sim detector.
+ * Applied as a per-story decorator, none of this wrapper appears in the docs
+ * source snippet — only the component itself does.
+ */
+export function withCameraSim(sim: OphydSim, detectorConfig: DetectorConfig): Decorator {
+    const transport = createOphydSimTransport(sim);
+    const cameraSocketFactory: CameraSocketFactory = createSimDetectorCameraSocketFactory(
+        sim,
+        detectorConfig,
+    );
+    return function CameraSimDecorator(Story) {
+        return (
+            <OphydSimProvider sim={sim}>
+                <OphydTransportProvider
+                    transport={transport}
+                    cameraSocketFactory={cameraSocketFactory}
+                >
+                    <Story />
+                </OphydTransportProvider>
+            </OphydSimProvider>
+        );
+    };
+}
+
+/**
+ * Supplies a device-socket transport (e.g. a mock) to descendants. Used for the
+ * `*Ophyd` components, which talk over the device socket that ophyd-sim's PV
+ * transport doesn't serve.
+ */
+export function withDeviceTransport(deviceTransport: OphydDeviceTransport): Decorator {
+    return function DeviceTransportDecorator(Story) {
+        return (
+            <OphydTransportProvider deviceTransport={deviceTransport}>
+                <Story />
+            </OphydTransportProvider>
+        );
+    };
+}


### PR DESCRIPTION
- New Storybook Documentation -> Ophyd Sim page (adapted from the ophyd-sim README) with an embedded live motor-controller demo.
- New Ophyd Components folder with sim-driven stories: Hexapod, DeviceControllerBox, Shutter, TableDeviceControllerWithRBV, BeamEnergyOphyd, BeamEnergyPV, CameraContainer, SignalMonitorPlotOphyd, SignalMonitorPlotPV, Beamstop, EnergyVsCurrentPlotPV.
- Components are wired to ophyd-sim via decorators only, with pinned docs source snippets so no provider boilerplate shows in the "Show code" panel. The device-socket components use a small mock device transport.
- CameraContainer: add optional autoStart prop (forwarded to CameraCanvas) so a viewer can stream on mount; backward compatible.